### PR TITLE
Setup Publishing to GitHub Packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,5 +7,12 @@
         "name": "Kyle Banks",
         "url": "https://github.com/KyleBanks/scene-ref-attribute"
     },
-    "license": "MIT"
+    "license": "MIT",
+    "publishConfig": {
+        "registry": "https://npm.pkg.github.com/@mgranddev"
+    },
+    "repository": {
+        "url": "git@github.com:mgranddev/scene-ref-attribute.git",
+        "type": "git"
+    }
 }


### PR DESCRIPTION
This adds support for publishing to the GitHub Packages npm registry.